### PR TITLE
Adding CLI and rate

### DIFF
--- a/main.py
+++ b/main.py
@@ -18,6 +18,7 @@ def new_rule(interface):
     duplicate = request.form['Duplicate']
     reorder = request.form['Reorder']
     corrupt = request.form['Corrupt']
+    rate = request.form['Rate']
 
     # remove old setup
     command = 'tc qdisc del dev %s root netem' % interface
@@ -27,6 +28,8 @@ def new_rule(interface):
 
     # apply new setup
     command = 'tc qdisc add dev %s root netem' % interface
+    if rate != '':
+        command += ' rate %smbit' % rate
     if delay != '':
         command += ' delay %sms' % delay
     if loss != '':
@@ -66,6 +69,7 @@ def get_active_rules():
 
 def parse_rule(splitted_rule):
     rule = {'name':      None,
+            'rate':      None,
             'delay':     None,
             'loss':      None,
             'duplicate': None,
@@ -75,6 +79,8 @@ def parse_rule(splitted_rule):
     for argument in splitted_rule:
         if argument == 'dev':
             rule['name'] = splitted_rule[i+1]
+        elif argument == 'rate':
+            rule['rate'] = splitted_rule[i + 1].split('M')[0]
         elif argument == 'delay':
             rule['delay'] = splitted_rule[i + 1]
         elif argument == 'loss':

--- a/templates/main.html
+++ b/templates/main.html
@@ -18,9 +18,9 @@
                         <th>New Value</th>
                     </tr>
                     <tr>
-                        <td>Throughput:</td>
+                        <td>Rate:</td>
                         <td>{{ rule['rate'] }}</td>
-                        <td><input type="text" name="Rate" size="5"> in Mbps</td>
+                        <td><input type="text" name="Rate" size="5"> in Mbit</td>
                     </tr>
                     <tr>
                         <td>Delay:</td>

--- a/templates/main.html
+++ b/templates/main.html
@@ -18,6 +18,11 @@
                         <th>New Value</th>
                     </tr>
                     <tr>
+                        <td>Throughput:</td>
+                        <td>{{ rule['rate'] }}</td>
+                        <td><input type="text" name="Rate" size="5"> in Mbps</td>
+                    </tr>
+                    <tr>
                         <td>Delay:</td>
                         <td>{{ rule['delay'] }}</td>
                         <td><input type="text" name="Delay" size="5"> in ms</td>


### PR DESCRIPTION
These commits add a command line interface to the tool, enabling the user to select the interface by either regex or interfaces names list or both. It also allows the user to run the tool on a specific port or ip and in debug mode.

```
usage: main.py [-h] [--ip IP] [--port PORT] [--dev [DEV [DEV ...]]]
               [--regex REGEX] [--debug]

TC web GUI

optional arguments:
  -h, --help            show this help message and exit
  --ip IP               The IP where the server is listening
  --port PORT           The port where the server is listening
  --dev [DEV [DEV ...]]
                        The interfaces to restrict to
  --regex REGEX         A regex to match interfaces
  --debug               Run Flask in debug mode
```
It also adds the rate feature of netem.