### PR TITLE
Parse --port option as integer number

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ def parse_arguments():
     parser = argparse.ArgumentParser(description='TC web GUI')
     parser.add_argument('--ip', type=str, required=False,
                         help='The IP where the server is listening')
-    parser.add_argument('--port', type=str, required=False,
+    parser.add_argument('--port', type=int, required=False,
                         help='The port where the server is listening')
     parser.add_argument('--dev', type=str, nargs='*', required=False,
                         help='The interfaces to restrict to')


### PR DESCRIPTION
`--port` option does not work because flask requires integer number as port instead of a string.

```
$ sudo python3 tcgui/main.py --ip 0.0.0.0 --port 80
Traceback (most recent call last):
  File "tcgui/main.py", line 164, in <module>
    app.run(**app_args)
  File "/usr/lib/python3/dist-packages/flask/app.py", line 841, in run
    run_simple(host, port, self, **options)
  File "/usr/lib/python3/dist-packages/werkzeug/serving.py", line 748, in run_simple
    raise TypeError('port must be an integer')
TypeError: port must be an integer
```
