### PR TITLE
Adding sort function on rules to get alphabetical list of interfaces.

### DIFF
--- a/main.py
+++ b/main.py
@@ -152,6 +152,7 @@ def get_active_rules():
         if rule["name"] and rule["name"] not in dev:
             rules.append(rule)
             dev.add(rule["name"])
+            rules.sort(key=lambda x: x["name"])
     return rules
 
 


### PR DESCRIPTION
I have implemented the fix that @shawndcorn made in #21. I just added the single line adding the sort function. 
Thanks @shawndcorn !